### PR TITLE
Create a buffer to remember the N previous seeds.

### DIFF
--- a/A-RYTH-MATIK/Certainty/Certainty.ino
+++ b/A-RYTH-MATIK/Certainty/Certainty.ino
@@ -57,7 +57,7 @@
 
 // Flag for enabling debug print to serial monitoring output.
 // Note: this affects performance and locks LED 4 & 5 on HIGH.
-#define DEBUG
+// #define DEBUG
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
 SimpleRotary encoder(ENCODER_PIN1, ENCODER_PIN2, ENCODER_SW_PIN);
@@ -112,7 +112,6 @@ void setup() {
 
     // Initial random seed and step length from EEPROM or default values.
     InitState();
-    packet.Debug();
 
     // Initialize each of the outputs with it's GPIO pins and probability.
     outputs[0].Init(OUT_CH1, LED_CH1, 0.96);
@@ -226,14 +225,8 @@ void UpdateParameter(byte encoder_dir) {
 // Randomize the current seed if the encoder has moved in either direction.
 void UpdateSeed(byte dir) {
     if (dir == 0) return;
-    if (dir == 1) {
-        packet.NextSeed();
-        packet.Debug();
-    }
-    if (dir == 2) {
-        packet.PrevSeed();
-        packet.Debug();
-    }
+    if (dir == 1) packet.NextSeed();
+    if (dir == 2) packet.PrevSeed();
     update_display = true;
     state_changed = true;
 }

--- a/A-RYTH-MATIK/Certainty/Certainty.ino
+++ b/A-RYTH-MATIK/Certainty/Certainty.ino
@@ -26,6 +26,7 @@
 
 // Script specific output class.
 #include "output.h"
+#include "seed_packet.h"
 
 // OLED Display config
 #define OLED_ADDRESS 0x3C
@@ -56,7 +57,7 @@
 
 // Flag for enabling debug print to serial monitoring output.
 // Note: this affects performance and locks LED 4 & 5 on HIGH.
-// #define DEBUG
+#define DEBUG
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
 SimpleRotary encoder(ENCODER_PIN1, ENCODER_PIN2, ENCODER_SW_PIN);
@@ -89,9 +90,9 @@ enum Parameter {
 Parameter selected_param = PARAM_NONE;
 
 // Script state variables.
-uint16_t seed;             // Store the current seed used for psudo random number generator
 uint8_t step_length = 16;  // Length of psudo random trigger sequence (default 16 steps)
 uint8_t step_count = 0;    // Count of trigger steps since reset
+SeedPacket packet;
 
 int clk = 0;  // External CLK trigger input read value
 int old_clk = 0;
@@ -106,11 +107,12 @@ void setup() {
 // Only enable Serial monitoring if DEBUG is defined.
 // Note: this affects performance and locks LED 4 & 5 on HIGH.
 #ifdef DEBUG
-    Serial.begin(9600);
+    Serial.begin(115200);
 #endif
 
     // Initial random seed and step length from EEPROM or default values.
     InitState();
+    packet.Debug();
 
     // Initialize each of the outputs with it's GPIO pins and probability.
     outputs[0].Init(OUT_CH1, LED_CH1, 0.96);
@@ -158,7 +160,7 @@ void loop() {
     // When step count wraps, reset step count and reseed.
     if (clk_state == STATE_RISING) {
         step_count = ++step_count % step_length;
-        if (step_count == 0) Reseed();
+        if (step_count == 0) packet.Reseed();
         update_display = true;
     }
 
@@ -187,40 +189,17 @@ void InitState() {
     // Read previously stored seed from EEPROM memory. If it is empty, generate a new random seed.
     uint16_t _seed;
     EEPROM.get(SEED_ADDR, _seed);
-    if (_seed != 0) {
-        seed = _seed;
+    if (_seed != 0xFFFF) {
+        packet.SetSeed(_seed);
     } else {
-        NewSeed();
+        packet.NewRandomSeed();
     }
     // Read previously stored step_length from EEPROM memory. Update step_length if the value is non-zero.
     uint8_t _step_length;
     EEPROM.get(LENGTH_ADDR, _step_length);
-    if (_step_length != 0) {
+    if (_step_length != 0 && _step_length != 0xFF) {
         SetLength(_step_length);
     }
-}
-
-// Reset the seed and pattern length to restart the psudo random deterministic pattern.
-void Reset() {
-    Reseed();
-    step_count = 0;
-    update_display = true;
-}
-
-// Generate a new random seed.
-void NewSeed() {
-    randomSeed(micros());
-    seed = random(UINT16_MAX);
-    Reseed();
-    update_display = true;
-    state_changed = true;
-}
-
-// Set the pattern length..
-void SetLength(uint8_t _step_length) {
-    step_length = constrain(_step_length, MIN_LENGTH, MAX_LENGTH);
-    update_display = true;
-    state_changed = true;
 }
 
 // Save state to EEPROM if state has changed.
@@ -228,12 +207,14 @@ void SaveChanges() {
     if (!state_changed) return;
     state_changed = false;
     EEPROM.put(LENGTH_ADDR, step_length);
-    EEPROM.put(SEED_ADDR, seed);
+    EEPROM.put(SEED_ADDR, packet.GetSeed());
 }
 
-// Reseed the random number generator with the current seed.
-void Reseed() {
-    randomSeed(seed);
+// Reset the seed and pattern length to restart the psudo random deterministic pattern.
+void Reset() {
+    packet.Reseed();
+    step_count = 0;
+    update_display = true;
 }
 
 // Update the current selected parameter with the current movement of the encoder.
@@ -244,13 +225,30 @@ void UpdateParameter(byte encoder_dir) {
 
 // Randomize the current seed if the encoder has moved in either direction.
 void UpdateSeed(byte dir) {
-    if (dir != 0) NewSeed();
+    if (dir == 0) return;
+    if (dir == 1) {
+        packet.NextSeed();
+        packet.Debug();
+    }
+    if (dir == 2) {
+        packet.PrevSeed();
+        packet.Debug();
+    }
+    update_display = true;
+    state_changed = true;
 }
 
 // Adjust the step length for the given input direction (1=increment, 2=decrement).
 void UpdateLength(byte dir) {
     if (dir == 1 && step_length <= MAX_LENGTH) SetLength(++step_length);
     if (dir == 2 && step_length >= MIN_LENGTH) SetLength(--step_length);
+}
+
+// Set the pattern length..
+void SetLength(uint8_t _step_length) {
+    step_length = constrain(_step_length, MIN_LENGTH, MAX_LENGTH);
+    update_display = true;
+    state_changed = true;
 }
 
 // UI display of app state.
@@ -312,7 +310,7 @@ void UpdateDisplay() {
     display.drawPixel(85, 57, 1);
     display.drawPixel(87, 60, 1);
     display.setCursor(94, 56);
-    display.println(String(seed, HEX));
+    display.println(String(packet.GetSeed(), HEX));
 
     // Show edit icon for seed if it's selected.
     if (selected_param == PARAM_SEED) {

--- a/A-RYTH-MATIK/Certainty/seed_packet.h
+++ b/A-RYTH-MATIK/Certainty/seed_packet.h
@@ -14,9 +14,7 @@ class SeedPacket {
     void SetSeed(uint16_t seed) {
         // If the buffer is full, shift elements
         if (buffer_length_ == SIZE_OF_BUFFER) {
-            for (int i = 0; i < SIZE_OF_BUFFER - 1; i++) {
-                memcpy(&packet_[i], &packet_[i + 1], sizeof(uint16_t));
-            }
+            memcpy(&packet_[0], &packet_[1], sizeof(uint16_t) * SIZE_OF_BUFFER);
         }
 
         // Write new seed to buffer.

--- a/A-RYTH-MATIK/Certainty/seed_packet.h
+++ b/A-RYTH-MATIK/Certainty/seed_packet.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#define SIZE_OF_BUFFER 8
+
+class SeedPacket {
+   public:
+    SeedPacket() {}
+    ~SeedPacket() {}
+
+    void Debug() {
+        Serial.println("Packet: [" + 
+            String(packet_[0]) + ", " + 
+            String(packet_[1]) + ", " + 
+            String(packet_[2]) + ", " + 
+            String(packet_[3]) + ", " + 
+            String(packet_[4]) + ", " + 
+            String(packet_[5]) + ", " + 
+            String(packet_[6]) + ", " + 
+            String(packet_[7]) + "] "
+            "\tr: " + String(read_index_) +
+            "\tw: " + String(write_index_) +
+            "\tb: " + String(buffer_length_)
+            );
+    }
+
+    void NewRandomSeed() {
+        SetSeed(GetRandom());
+    }
+
+    void SetSeed(uint16_t seed) {
+        // Generate new seed and write to buffer.
+        // packet_[write_index_] = static_cast<uint16_t>(seed);
+        packet_[write_index_] = seed;
+        Reseed();
+
+        write_index_++;
+        if (write_index_ == SIZE_OF_BUFFER) {
+            write_index_ = 0;
+        }
+
+        buffer_length_ = constrain(buffer_length_ + 1, 0, SIZE_OF_BUFFER);
+    };
+
+    void NextSeed() {
+        read_index_ = ++read_index_ % SIZE_OF_BUFFER;
+
+        // If we are at the write index, add a new seed to the buffer.
+        if (read_index_ == write_index_) {
+            randomSeed(micros());  // Ensure new seeds are not deterministic
+            NewRandomSeed();
+        }
+    }
+
+    void PrevSeed() {
+        // Don't wrap if we haven't filled up the buffer yet.
+        if (read_index_ == 0 && buffer_length_ < SIZE_OF_BUFFER) {
+            return;
+        }
+
+        // Check if we're at the last position. If so, return the current seed.
+        if (read_index_ - 1 == write_index_ || (read_index_ == 0 && write_index_ == SIZE_OF_BUFFER - 1)) {
+            return;
+        }
+
+        // Decrement the read index and wrap if necessary.
+        if (read_index_ == 0) {
+                read_index_ = buffer_length_ - 1;
+        } else {
+            read_index_--;
+        }
+    }
+
+    uint16_t GetSeed() {
+        return packet_[read_index_];
+    }
+
+    void Reseed() {
+        randomSeed(GetSeed());
+    };
+
+    uint16_t GetRandom() {
+        return random(UINT16_MAX);
+    }
+
+   private:
+    uint16_t packet_[SIZE_OF_BUFFER] = {GetRandom()};
+    uint8_t read_index_ = 0;
+    uint8_t write_index_ = 0;
+    uint8_t buffer_length_ = 0;
+};

--- a/A-RYTH-MATIK/Certainty/seed_packet.h
+++ b/A-RYTH-MATIK/Certainty/seed_packet.h
@@ -1,73 +1,49 @@
 #pragma once
 
-#define SIZE_OF_BUFFER 8
+#define SIZE_OF_BUFFER 4
 
 class SeedPacket {
    public:
     SeedPacket() {}
     ~SeedPacket() {}
 
-    void Debug() {
-        Serial.println("Packet: [" + 
-            String(packet_[0]) + ", " + 
-            String(packet_[1]) + ", " + 
-            String(packet_[2]) + ", " + 
-            String(packet_[3]) + ", " + 
-            String(packet_[4]) + ", " + 
-            String(packet_[5]) + ", " + 
-            String(packet_[6]) + ", " + 
-            String(packet_[7]) + "] "
-            "\tr: " + String(read_index_) +
-            "\tw: " + String(write_index_) +
-            "\tb: " + String(buffer_length_)
-            );
-    }
-
     void NewRandomSeed() {
         SetSeed(GetRandom());
     }
 
     void SetSeed(uint16_t seed) {
-        // Generate new seed and write to buffer.
-        // packet_[write_index_] = static_cast<uint16_t>(seed);
+        // If the buffer is full, shift elements
+        if (buffer_length_ == SIZE_OF_BUFFER) {
+            for (int i = 0; i < SIZE_OF_BUFFER - 1; i++) {
+                memcpy(&packet_[i], &packet_[i + 1], sizeof(uint16_t));
+            }
+        }
+
+        // Write new seed to buffer.
         packet_[write_index_] = seed;
         Reseed();
 
-        write_index_++;
-        if (write_index_ == SIZE_OF_BUFFER) {
-            write_index_ = 0;
-        }
-
-        buffer_length_ = constrain(buffer_length_ + 1, 0, SIZE_OF_BUFFER);
+        if (write_index_ < SIZE_OF_BUFFER - 1) write_index_++;
+        if (buffer_length_ < SIZE_OF_BUFFER) buffer_length_++;
     };
 
     void NextSeed() {
-        read_index_ = ++read_index_ % SIZE_OF_BUFFER;
+        // Increment read index allowing for exceeding buffer size to indicate
+        // a new seed is needed.
+        if (read_index_ < SIZE_OF_BUFFER) read_index_++;
 
-        // If we are at the write index, add a new seed to the buffer.
-        if (read_index_ == write_index_) {
+        // If read index reaches the buffer length, add a new seed.
+        if (read_index_ == buffer_length_) {
             randomSeed(micros());  // Ensure new seeds are not deterministic
             NewRandomSeed();
         }
+
+        // Constrain the read index to the buffer size.
+        if (read_index_ == SIZE_OF_BUFFER) read_index_--;
     }
 
     void PrevSeed() {
-        // Don't wrap if we haven't filled up the buffer yet.
-        if (read_index_ == 0 && buffer_length_ < SIZE_OF_BUFFER) {
-            return;
-        }
-
-        // Check if we're at the last position. If so, return the current seed.
-        if (read_index_ - 1 == write_index_ || (read_index_ == 0 && write_index_ == SIZE_OF_BUFFER - 1)) {
-            return;
-        }
-
-        // Decrement the read index and wrap if necessary.
-        if (read_index_ == 0) {
-                read_index_ = buffer_length_ - 1;
-        } else {
-            read_index_--;
-        }
+        if (read_index_ > 0) read_index_--;
     }
 
     uint16_t GetSeed() {
@@ -83,7 +59,7 @@ class SeedPacket {
     }
 
    private:
-    uint16_t packet_[SIZE_OF_BUFFER] = {GetRandom()};
+    uint16_t packet_[SIZE_OF_BUFFER] = {};
     uint8_t read_index_ = 0;
     uint8_t write_index_ = 0;
     uint8_t buffer_length_ = 0;


### PR DESCRIPTION
This change modifies the way selecting a new random seed works. A buffer will store the last 8 random seeds, allowing you to move the encoder right to generate a new seed, and each subsequent seed will be added to the buffer. Moving the encoder to the left will cycle through any previous seeds that exist in the buffer. This will allow us to queue up a few seeds and move through them if we want to build verse / chorus / bridge motifs in our music.