### PR TITLE
Time Bandit

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         module: ["A-RYTH-MATIK"]
-        firmware: ["BitGarden", "Uncertainty"]
+        firmware: ["BitGarden", "Uncertainty", "TimeBandit"]
 
     steps:
       - name: Clone repo

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "A-RYTH-MATIK/Uncertainty/src/libmodulove"]
 	path = A-RYTH-MATIK/Uncertainty/src/libmodulove
 	url = https://github.com/awonak/libmodulove.git
+[submodule "A-RYTH-MATIK/TimeBandit/src/libmodulove"]
+	path = A-RYTH-MATIK/TimeBandit/src/libmodulove
+	url = https://github.com/awonak/libmodulove.git

--- a/A-RYTH-MATIK/TimeBandit/TimeBandit.ino
+++ b/A-RYTH-MATIK/TimeBandit/TimeBandit.ino
@@ -1,30 +1,79 @@
+/**
+ * @file TimeBandit.ino
+ * @author Adam Wonak (https://github.com/awonak/)
+ * @brief Fixed binary clock divider and sub oscillator.
+ * @version 0.1
+ * @date 2023-10-29
+ *
+ * @copyright Copyright (c) 2023
+ *
+ * The 6 digital outputs will produce a 50% duty cycle square wave in fixed
+ * binary divisions of the incoming CLK signal. This can be used as a typical
+ * clock divider or provide sub octaves of the incoming audio rate signal.
+ * Each output is one octave lower than the previous.
+ *
+ * ENCODER: Unused.
+ *
+ * CLK: Clock input used to derrive fixed binary divisions.
+ *
+ * RST: Trigger this input to reset the division counter.
+ *
+ */
 #include "src/libmodulove/arythmatik.h"
 
 using namespace modulove;
 using namespace arythmatik;
 
-struct Clock {
+struct ClockDivision {
+    // Instance of an A-RYTH-MATIK digital output.
     modulove::DigitalOutput output;
+    // Binary division of the incoming clock.
     int division;
 };
 
 // Declare A-RYTH-MATIK hardware variable.
 Arythmatik hw;
-Clock clocks[OUTPUT_COUNT];
-
-bool updateDisplay = true;
+ClockDivision clockDiv[OUTPUT_COUNT];
 byte counter;
 
 void setup() {
     // Initialize the A-RYTH-MATIK peripherials.
     hw.Init();
 
-    clocks[0] = {hw.outputs[0], 1};
-    clocks[1] = {hw.outputs[1], 2};
-    clocks[2] = {hw.outputs[2], 4};
-    clocks[3] = {hw.outputs[3], 8};
-    clocks[4] = {hw.outputs[4], 16};
-    clocks[5] = {hw.outputs[5], 32};
+    // Define each of the fixed clock divisions.
+    clockDiv[0] = {hw.outputs[0], 1};
+    clockDiv[1] = {hw.outputs[1], 2};
+    clockDiv[2] = {hw.outputs[2], 4};
+    clockDiv[3] = {hw.outputs[3], 8};
+    clockDiv[4] = {hw.outputs[4], 16};
+    clockDiv[5] = {hw.outputs[5], 32};
+
+    // Display each clock division on the OLED.
+    hw.display.clearDisplay();
+
+    // Draw page title.
+    hw.display.setTextSize(0);
+    hw.display.setCursor(36, 0);
+    hw.display.println("Time Bandit");
+    hw.display.drawFastHLine(0, 10, SCREEN_WIDTH, WHITE);
+
+    // Draw each clock division.
+    double ymod = SCREEN_HEIGHT * 0.25;
+    double xmod = SCREEN_WIDTH * 0.6;
+    int ypos = 4;
+    int xpos = 6;
+    int count;
+    for (int i = 0; i < 2; i++) {
+        for (int i = 0; i < 3; i++) {
+            ypos += ymod;
+            hw.display.setCursor(xpos, ypos);
+            hw.display.println("div: " + String(clockDiv[count].division));
+            count++;
+        }
+        xpos += xmod;
+        ypos = 4;
+    }
+    hw.display.display();
 }
 
 void loop() {
@@ -36,42 +85,14 @@ void loop() {
         counter++;
         for (int i = 0; i < OUTPUT_COUNT; i++) {
             // Bitwise logical check if division is high.
-            (counter & clocks[i].division)
-                ? clocks[i].output.High()
-                : clocks[i].output.Low();
+            (counter & clockDiv[i].division)
+                ? clockDiv[i].output.High()
+                : clockDiv[i].output.Low();
         }
     }
 
-    // Display the current counter step on the OLED.
-    if (updateDisplay) {
-        updateDisplay = false;
-        hw.display.clearDisplay();
-        PageTitle("Time Bandit");
-
-        double ymod = SCREEN_HEIGHT * 0.25;
-        double xmod = SCREEN_WIDTH * 0.6;
-        int ypos = 4;
-        int xpos = 6;
-        int count;
-
-        for (int i = 0; i < 2; i++) {
-            for (int i = 0; i < 3; i++) {
-                ypos += ymod;
-                hw.display.setCursor(xpos, ypos);
-                hw.display.println("div: " + String(clocks[count].division));
-                count++;
-            }
-            xpos += xmod;
-            ypos = 4;
-        }
-        hw.display.display();
+    // Reset the clock division counter on RST input.
+    if (hw.rst.State() == DigitalInput::STATE_RISING) {
+        counter = 0;
     }
-}
-
-void PageTitle(String title) {
-    // Draw page title.
-    hw.display.setTextSize(0);
-    hw.display.setCursor(36, 0);
-    hw.display.println(title);
-    hw.display.drawFastHLine(0, 10, SCREEN_WIDTH, WHITE);
 }

--- a/A-RYTH-MATIK/TimeBandit/TimeBandit.ino
+++ b/A-RYTH-MATIK/TimeBandit/TimeBandit.ino
@@ -1,0 +1,77 @@
+#include "src/libmodulove/arythmatik.h"
+
+using namespace modulove;
+using namespace arythmatik;
+
+struct Clock {
+    modulove::DigitalOutput output;
+    int division;
+};
+
+// Declare A-RYTH-MATIK hardware variable.
+Arythmatik hw;
+Clock clocks[OUTPUT_COUNT];
+
+bool updateDisplay = true;
+byte counter;
+
+void setup() {
+    // Initialize the A-RYTH-MATIK peripherials.
+    hw.Init();
+
+    clocks[0] = {hw.outputs[0], 1};
+    clocks[1] = {hw.outputs[1], 2};
+    clocks[2] = {hw.outputs[2], 4};
+    clocks[3] = {hw.outputs[3], 8};
+    clocks[4] = {hw.outputs[4], 16};
+    clocks[5] = {hw.outputs[5], 32};
+}
+
+void loop() {
+    // Read cv inputs and process encoder state to determine state for this loop.
+    hw.ProcessInputs();
+
+    // Advance the counter on CLK input
+    if (hw.clk.State() == DigitalInput::STATE_RISING) {
+        counter++;
+        for (int i = 0; i < OUTPUT_COUNT; i++) {
+            // Bitwise logical check if division is high.
+            (counter & clocks[i].division)
+                ? clocks[i].output.High()
+                : clocks[i].output.Low();
+        }
+    }
+
+    // Display the current counter step on the OLED.
+    if (updateDisplay) {
+        updateDisplay = false;
+        hw.display.clearDisplay();
+        PageTitle("Time Bandit");
+
+        double ymod = SCREEN_HEIGHT * 0.25;
+        double xmod = SCREEN_WIDTH * 0.6;
+        int ypos = 4;
+        int xpos = 6;
+        int count;
+
+        for (int i = 0; i < 2; i++) {
+            for (int i = 0; i < 3; i++) {
+                ypos += ymod;
+                hw.display.setCursor(xpos, ypos);
+                hw.display.println("div: " + String(clocks[count].division));
+                count++;
+            }
+            xpos += xmod;
+            ypos = 4;
+        }
+        hw.display.display();
+    }
+}
+
+void PageTitle(String title) {
+    // Draw page title.
+    hw.display.setTextSize(0);
+    hw.display.setCursor(36, 0);
+    hw.display.println(title);
+    hw.display.drawFastHLine(0, 10, SCREEN_WIDTH, WHITE);
+}

--- a/pages/content/arythmatik.md
+++ b/pages/content/arythmatik.md
@@ -56,3 +56,29 @@ CV1-6: Gate output with decreasing probability.
 ```
 
 {{< firmware_button hex="A-RYTH-MATIK_Uncertainty.hex" buttonText="Flash Uncertainty Firmware">}}
+
+
+## Time Bandit
+
+Fixed binary clock divider and sub oscillator. [[source](https://github.com/awonak/HagiwoModulove/tree/main/A-RYTH-MATIK/TimeBandit/TimeBandit.ino)]
+
+The 6 digital outputs will produce a 50% duty cycle square wave in fixed
+binary divisions of the incoming CLK signal. This can be used as a typical
+clock divider or provide sub octaves of the incoming audio rate signal.
+Each output is one octave lower than the previous.
+
+
+{{< youtube xAgkP6kvcgA >}}
+
+```yaml
+Encoder: Unused.
+
+CLK: Clock input used to produce fixed binary divisions.
+
+RST: Trigger this input to reset the division counter.
+
+CV1-6: Binary clock divisions of 1, 2, 4, 8, 16, 32.
+
+```
+
+{{< firmware_button hex="A-RYTH-MATIK_TimeBandit.hex" buttonText="Flash Time Bandit Firmware">}}


### PR DESCRIPTION
 6 digital outputs will produce a 50% duty cycle square wave in fixed binary divisions of the incoming CLK signal. This can be used as a typical clock divider or provide sub octaves of the incoming audio rate signal. Each output is one octave lower than the previous.