### PR TITLE
Add Perlin Noise firmware for Sync LFO / MVMT

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -25,6 +25,7 @@ jobs:
           arduino-cli lib install "Adafruit GFX Library"
           arduino-cli lib install "Adafruit SSD1306"
           arduino-cli lib install SimpleRotary
+          arduino-cli lib install FastLED
 
       - name: Compile sketch and rename output file for release
         working-directory: ./${{ matrix.module}}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
         matrix:
           module: ["SyncLFO"]
-          firmware: ["ADSR", "Baby4", "GenerativeSequencer", "MultiModeEnv", "Polyrhythm"]
+          firmware: ["ADSR", "Baby4", "GenerativeSequencer", "MultiModeEnv", "Polyrhythm", "PerlinNoise"]
 
     steps:
         - name: Clone repo

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -69,6 +69,7 @@ jobs:
           wget https://github.com/awonak/HagiwoModulove/releases/latest/download/SyncLFO_GenerativeSequencer.hex
           wget https://github.com/awonak/HagiwoModulove/releases/latest/download/SyncLFO_MultiModeEnv.hex
           wget https://github.com/awonak/HagiwoModulove/releases/latest/download/SyncLFO_Polyrhythm.hex
+          wget https://github.com/awonak/HagiwoModulove/releases/latest/download/SyncLFO_PerlinNoise.hex
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ You're now ready to start hacking!
 * [Adafruit_SSD1306](https://github.com/adafruit/Adafruit_SSD1306)
 * [Simple Rotary](https://github.com/mprograms/SimpleRotary/tree/master)
 * [AVR IO](https://github.com/avrdudes/avr-libc)
+* [FastLED](https://github.com/FastLED/FastLED)

--- a/SyncLFO/PerlinNoise/PerlinNoise.ino
+++ b/SyncLFO/PerlinNoise/PerlinNoise.ino
@@ -54,7 +54,8 @@ const float noiseReadFactor = 0.0098;
 bool gate = 1;  // External gate input detect: 0=gate off, 1=gate on
 bool old_gate = 0;
 int nx = 0;             // Perlin noise buffer x read value
-int seed = random16();  // Start with a new random Perlin noise Y-axis each time.
+int ny = 0;             // Perlin noise buffer y read value
+int seed = random16();  // Start with a new random Perlin noise Z-axis each time.
 byte depth = 0;         // Bitcrush depth.
 byte val = 0;           // current value from the perlin noise algorithm
 byte hold = 0;          // held output value for s&h / t&h
@@ -109,7 +110,7 @@ void loop() {
     if (currentTime - previousTime > frequencyInterval) {
         // Calculate the output value.
         nx += pow(2, analogRead(P2) * noiseReadFactor);
-        val = inoise8(nx, seed);
+        val = inoise8(nx, ++ny, seed);
         if (offset > 0) {
             val = constrain(val + offset, 0, 255);
         } else {

--- a/SyncLFO/PerlinNoise/PerlinNoise.ino
+++ b/SyncLFO/PerlinNoise/PerlinNoise.ino
@@ -60,8 +60,7 @@ bool old_gate = 0;
 int nx = 0;       // Perlin noise buffer x read value
 int ny = 0;       // Perlin noise buffer y read value
 byte val = 0;     // current value from the perlin noise algorithm
-byte hold = 0;    // held output value
-byte output = 0;  // output value used according to selected mode + gate state.
+byte hold = 0;    // held output value for s&h / t&h
 
 enum InputMode {
     OPEN,
@@ -110,21 +109,7 @@ void loop() {
     val = bitcrush(val, depth);
 
     // Determine the output value based on the current selected input mode.
-    switch (inputMode) {
-        case OPEN:
-            output = val;
-            break;
-        case SAMPLE_HOLD:
-            output = hold;
-            break;
-        case TRACK_HOLD:
-            output = (gate == 1) ? hold : val;
-            break;
-        case GATE:
-            output = (gate == 1) ? val : 0;
-            break;
-    }
-    analogWrite(CV_OUT, output);
+    analogWrite(CV_OUT, output(inputMode));
 
     // Frequency or rate of change.
     float read = (1023 * freqFactor) - (analogRead(P1) * freqFactor);
@@ -157,5 +142,18 @@ InputMode readMode() {
         case 3:
             return GATE;
             break;
+    }
+}
+
+byte output(InputMode inputMode) {
+    switch (inputMode) {
+        case OPEN:
+            return val;
+        case SAMPLE_HOLD:
+            return hold;
+        case TRACK_HOLD:
+            return (gate == 1) ? hold : val;
+        case GATE:
+            return (gate == 1) ? val : 0;
     }
 }

--- a/SyncLFO/PerlinNoise/PerlinNoise.ino
+++ b/SyncLFO/PerlinNoise/PerlinNoise.ino
@@ -11,7 +11,7 @@
  * Unlike random() in which each new random value has no correlation to it's
  * previous value, Perlin noise has a more organic appearance because it
  * produces a naturally ordered “smooth” sequence of pseudo-random numbers.
- * 
+ *
  * Additionally, the random values produced by the Perlin noise algorithm
  * adhere to a bell curve distribution, meaning the OUT cv will hover around
  * 5v and the BI cv output will hover around 0v.
@@ -57,10 +57,11 @@ const float noiseReadFactor = 0.0098;
 
 bool gate = 1;  // External gate input detect: 0=gate off, 1=gate on
 bool old_gate = 0;
-int nx = 0;       // Perlin noise buffer x read value
-int ny = 0;       // Perlin noise buffer y read value
-byte val = 0;     // current value from the perlin noise algorithm
-byte hold = 0;    // held output value for s&h / t&h
+int nx = 0;      // Perlin noise buffer x read value
+int ny = 0;      // Perlin noise buffer y read value
+byte depth = 0;  // Bitcrush depth.
+byte val = 0;    // current value from the perlin noise algorithm
+byte hold = 0;   // held output value for s&h / t&h
 
 enum InputMode {
     OPEN,
@@ -105,7 +106,7 @@ void loop() {
     // Calculate the output value.
     nx += pow(2, analogRead(P2) * noiseReadFactor);
     val = inoise8(nx, ++ny);
-    int depth = map(analogRead(P3), 0, 1023, 0, 7);
+    depth = map(analogRead(P3), 0, 1023, 0, 7);
     val = bitcrush(val, depth);
 
     // Determine the output value based on the current selected input mode.
@@ -132,16 +133,12 @@ InputMode readMode() {
     switch (analogRead(P4) >> 8) {
         case 0:
             return OPEN;
-            break;
         case 1:
             return SAMPLE_HOLD;
-            break;
         case 2:
             return TRACK_HOLD;
-            break;
         case 3:
             return GATE;
-            break;
     }
 }
 

--- a/pages/content/synclfo.md
+++ b/pages/content/synclfo.md
@@ -97,6 +97,39 @@ CV_OUT: Envelope Output
 
 {{< firmware_button hex="SyncLFO_MultiModeEnv.hex" buttonText="Flash MultiModeEnv Firmware" >}}
 
+## Perlin Noise
+
+Smooth random voltages to chaotic noise using the Perlin noise algorithm. [[source](https://github.com/awonak/HagiwoModulove/blob/main/SyncLFO/PerlinNoise/PerlinNoise.ino)]
+
+Unlike random() in which each new random value has no correlation to it's
+previous value, Perlin noise has a more organic appearance because it
+produces a naturally ordered "smooth" sequence of pseudo-random numbers.
+
+Additionally, the random values produced by the Perlin noise algorithm
+adhere to a bell curve distribution, meaning the OUT cv will hover around
+5v and the BI cv output will hover around 0v. When the Knob 1 offset is
+fully CCW the output will produce 0-5v hovering around 2.5v and when it is
+fully CW the output will produce 5-10v hovering around 8.5v.
+
+{{< youtube 7n8kDnDUpMI >}}
+
+```yaml
+Knob 1: Offset: Increase or decrease the center point the voltage hovers around
+Knob 2: Frequency: the rate at which the value changes
+Knob 3: Bit Crush: Reduce the bit depth of the output
+Knob 4: Input mode: Open, Sample & Hold, Track & Hold, Gate
+
+Input Trigger/Gate Modes:
+    OPEN: The output will continually produce random voltages regardless of CLK input.
+    SAMPLE_HOLD: Produce a new stable random voltage upon each trigger input.
+    TRACK_HOLD: Track and Hold, output the random voltage and hold the value upon gate input.
+    GATE: Also known as Hold and Track, only output voltage while the Gate input is high.
+
+```
+
+{{< firmware_button hex="SyncLFO_PerlinNoise.hex" buttonText="Flash Perlin Noise Firmware" >}}
+
+
 ## Polyrhythm
 
 Generate polyrhythms based on 16 step counter knobs. [[source](https://github.com/awonak/HagiwoModulove/blob/main/SyncLFO/Polyrhythm/Polyrhythm.ino)]


### PR DESCRIPTION
Smooth random voltages to chaotic noise using the Perlin noise algorithm. Unlike random() in which each new random value has no correlation to it's previous value, Perlin noise has a more organic appearance because it produces a naturally ordered “smooth” sequence of pseudo-random numbers.

https://youtu.be/7n8kDnDUpMI